### PR TITLE
Use objectManager instead of new to create User

### DIFF
--- a/Classes/Controller/RegisterController.php
+++ b/Classes/Controller/RegisterController.php
@@ -238,7 +238,7 @@ class RegisterController extends ActionController
                 ]);
             } else {
                 // User does not exist, so add user now
-                $user = new User();
+                $user = $this->objectManager->get(User::class);
                 $user->setUsername($registration->getUsername());
                 $user->setEmail($registration->getEmail());
                 $user->setPassword(t3h::Password()->getHashedPassword($registration->getPassword()));


### PR DESCRIPTION
When using the objectManager instead of calling new User(), the extbase object configuration (typoscript: config.tx_extbase.objects.SaschaEnde\Users\Domain\Model\User). Thus the user can be extended with custom fields. Although the class SaschaEnde\Users\Domain\Model\User already contains code for dynamic properties, this doesn't work here as there is no uid set when the setter function gets called.